### PR TITLE
Fix list position top

### DIFF
--- a/src/List/index.js
+++ b/src/List/index.js
@@ -38,7 +38,7 @@ export default class List extends Component {
     const className = join(
       props.className,
       'react-combo__list',
-      'react-combo__list--' + props.listPosition,
+      `react-combo__list--${props.listPosition || 'bottom'}`,
       props.loading && 'react-combo__list--loading',
       !data.length && 'react-combo__list--empty'
     )
@@ -123,7 +123,6 @@ export default class List extends Component {
 }
 
 List.defaultProps = {
-  listPosition: 'bottom',
   isComboList: true,
 
   onItemMouseDown: () => {},

--- a/src/List/index.js
+++ b/src/List/index.js
@@ -33,12 +33,17 @@ export default class List extends Component {
       return null
     }
 
-    const data = this.props.data;
+    let data = this.props.data
+    
+    const listPosition = props.listPosition || 'bottom'
+    if (listPosition === 'top') {
+      data = data.slice().reverse()
+    }
 
     const className = join(
       props.className,
       'react-combo__list',
-      `react-combo__list--${props.listPosition || 'bottom'}`,
+      `react-combo__list--${listPosition}`,
       props.loading && 'react-combo__list--loading',
       !data.length && 'react-combo__list--empty'
     )
@@ -67,11 +72,19 @@ export default class List extends Component {
   }
 
   componentDidUpdate(prevProps){
-    if (prevProps.currentIndex != this.props.currentIndex){
-      const index = this.props.currentIndex;
+    const props = this.props
+    const currentIndex = props.currentIndex;
+    const listPosition = props.listPosition
 
-      if (index != null){
-        this.scrollToRow(index, index - (prevProps.currentIndex || 0) < 0? -1: 1)
+    // if index is falsy and listPosition, list should be scrolled to bottom
+    if (currentIndex == null && listPosition === 'top') {
+      this.scrollBottom()
+    }
+
+    if (prevProps.currentIndex != currentIndex){
+
+      if (currentIndex != null){
+        this.scrollToRow(currentIndex, currentIndex - (prevProps.currentIndex || 0) < 0? -1: 1)
       }
     }
   }
@@ -81,6 +94,12 @@ export default class List extends Component {
     const row = domNode? domNode.children[index]: null
 
     scrollToRowIfNeeded(row, direction)
+  }
+
+  scrollBottom(){
+    const domNode = findDOMNode(this)
+
+    domNode.scrollTop = domNode.offsetHeight
   }
 
   renderItem(item, index){

--- a/src/fieldMethods.js
+++ b/src/fieldMethods.js
@@ -173,6 +173,7 @@ const onFieldKeyDown = function(event){
 const navigate = function (dir) {
 
   dir = dir < 0? -1: 1
+  dir *= this.getDirectionSign()
 
   const currentIndex = this.p.currentIndex
   const listPosition = this.p.listPosition
@@ -180,13 +181,7 @@ const navigate = function (dir) {
   let newCurrentIndex
 
   if (currentIndex == null ){
-    // if listPosition is not defined default to 0, it is bottom to 0 else to last data item
-    if (listPosition === undefined || listPosition === 'bottom') {
-      newCurrentIndex = 0
-    } else {
-      newCurrentIndex = this.p.data.length - 1
-    }
-  
+    newCurrentIndex = 0 
   } else {
     newCurrentIndex = clamp(currentIndex + dir, 0, this.p.data.length - 1)
   }
@@ -289,6 +284,10 @@ const onHiddenFieldKeyDown = function(event){
   }
 }
 
+const getDirectionSign = function(){
+  return this.p.listPosition === 'bottom'? 1 : -1
+}
+
 export default {
   renderField,
   onFieldFocus,
@@ -301,6 +300,7 @@ export default {
   onHiddenFieldFocus,
   onHiddenFieldBlur,
   onHiddenFieldKeyDown,
+  getDirectionSign,
   getSelectionStart(){
     return getSelectionStart(findDOMNode(this.field))
   },

--- a/src/fieldMethods.js
+++ b/src/fieldMethods.js
@@ -175,11 +175,18 @@ const navigate = function (dir) {
   dir = dir < 0? -1: 1
 
   const currentIndex = this.p.currentIndex
+  const listPosition = this.p.listPosition
 
   let newCurrentIndex
 
   if (currentIndex == null ){
-    newCurrentIndex = 0
+    // if listPosition is not defined default to 0, it is bottom to 0 else to last data item
+    if (listPosition === undefined || listPosition === 'bottom') {
+      newCurrentIndex = 0
+    } else {
+      newCurrentIndex = this.p.data.length - 1
+    }
+  
   } else {
     newCurrentIndex = clamp(currentIndex + dir, 0, this.p.data.length - 1)
   }

--- a/style/list-item.scss
+++ b/style/list-item.scss
@@ -10,6 +10,7 @@ $selected: #c7e5ee;
 
 .react-combo__list-item--current {
   background: #e6f2ff;
+  background: red;
 }
 .react-combo__list-item--selected {
   background: $selected;


### PR DESCRIPTION
Scroll to bottom when currentIndex is null.
On keyup first item selected is first from bottom.
Items are in reverse order.currentIndexScroll to bottom when currentIndex is null.
